### PR TITLE
ARM64: Fixed invalid pt_regs address

### DIFF
--- a/src/libgcore/gcore_arm64.c
+++ b/src/libgcore/gcore_arm64.c
@@ -29,7 +29,7 @@ static int gpr_get(struct task_context *target,
 	BZERO(regs, sizeof(*regs));
 
 	readmem(machdep->get_stacktop(target->task) -
-		machdep->machspec->user_eframe_offset - SIZE(pt_regs), KVADDR,
+		machdep->machspec->user_eframe_offset, KVADDR,
 		regs, sizeof(struct user_pt_regs), "gpr_get: user_pt_regs",
 		gcore_verbose_error_handle());
 
@@ -126,7 +126,7 @@ static int compat_gpr_get(struct task_context *target,
 	BZERO(regs, sizeof(*regs));
 
 	readmem(machdep->get_stacktop(target->task) -
-		machdep->machspec->user_eframe_offset - SIZE(pt_regs), KVADDR,
+		machdep->machspec->user_eframe_offset, KVADDR,
 		&pt_regs, sizeof(struct pt_regs), "compat_gpr_get: pt_regs",
 		gcore_verbose_error_handle());
 


### PR DESCRIPTION
This fix follow the commit 19bfb92e50799a82f7ce6179fb35ccd82061bafd
    arm64: Fix miscalculation of the starting address of the pt_regs
    structure on the kernel stack

The machdep->machspec->user_eframe_offset value comes from crash
which already taken the size of pt_regs in to account.

Core was generated by `/init'.
 #0  0x0000000000000015 in ?? ()
(gdb) info registers
x0             0xffffff80080e1d3c -549620671172
...
x26            0xc79ecaf 209317039
x27            0xef412c356afbd300 -1206634617218804992
x28            0x7 7
x29            0xef412c356afbd300 -1206634617218804992
x30            0x16 22
sp             0x124 0x124
pc             0x15 0x15
cpsr           0x40000000 [ EL=0 Z ]
fpsr           0x10 16
fpcr           0x0 0

Signed-off-by: Hong YANG <hong.yang3@nio.com>