### PR TITLE
gcore: update set_context with upstream counterpart

### DIFF
--- a/src/gcore.c
+++ b/src/gcore.c
@@ -306,7 +306,7 @@ static void do_gcore(char *arg)
 
 		if (tc != CURRENT_CONTEXT()) {
 			gcore->orig_task = CURRENT_TASK();
-			(void) set_context(tc->task, NO_PID);
+			(void) set_context(tc->task, NO_PID, FALSE);
 		}
 
 		snprintf(gcore->corename, CORENAME_MAX_SIZE + 1, "core.%lu.%s",
@@ -340,7 +340,7 @@ static void do_gcore(char *arg)
 	}
 
 	if (gcore->orig_task)
-		(void)set_context(gcore->orig_task, NO_PID);
+		(void)set_context(gcore->orig_task, NO_PID, FALSE);
 
 }
 


### PR DESCRIPTION
With the introduction of upstream commit "Preparing for gdb stack unwind support" [1], the function set_context() is added by a 3rd parameter. Without this patch, the compiliation of gcore will fail.

The 3rd parameter of set_context() is used to sync the context of crash and gdb, so gdb can hold the the value of registers of current crash's task context, and gdb can output the stack unwinding for current task.

This have nothing to do with gcore, so simply set the 3rd parameter as FALSE.

[1]: https://github.com/lian-bo/crash/commit/d75d15d31b92f8882ccb15c960665e2c8a8d1c28

---
[1] will be merged shortly, and I will update the upstream status when merged.